### PR TITLE
fix: Comprehensive TypeScript build fixes for Vercel deployment

### DIFF
--- a/packages/app-store/stripepayment/lib/PaymentService.ts
+++ b/packages/app-store/stripepayment/lib/PaymentService.ts
@@ -120,7 +120,6 @@ export class PaymentService implements IAbstractPaymentService {
       const session = await this.stripe.checkout.sessions.create(
         {
           mode: "payment",
-          // @ts-expect-error - ui_mode exists at runtime but not in the type definitions yet
           ui_mode: "embedded",
           customer: customer.id,
           line_items: [

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -405,7 +405,7 @@ async function handler(
   const isPlatformBooking = !!platformClientId;
 
   const eventType = await getEventType({
-    eventTypeId: (rawBookingData.eventTypeId || 0) as number,
+    eventTypeId: Number(rawBookingData.eventTypeId) || 0,
     eventTypeSlug: rawBookingData.eventTypeSlug as string | undefined,
   });
 

--- a/packages/features/ee/teams/lib/payments.ts
+++ b/packages/features/ee/teams/lib/payments.ts
@@ -61,7 +61,6 @@ export const generateTeamCheckoutSession = async ({
   const session = await stripe.checkout.sessions.create({
     customer,
     mode: "subscription",
-    // @ts-expect-error - ui_mode exists at runtime but not in the type definitions yet
     ui_mode: "embedded",
     ...(dubCustomer?.discount?.couponId
       ? {
@@ -177,7 +176,6 @@ export const purchaseTeamOrOrgSubscription = async (input: {
   const session = await stripe.checkout.sessions.create({
     customer,
     mode: "subscription",
-    // @ts-expect-error - ui_mode exists at runtime but not in the type definitions yet
     ui_mode: "embedded",
     allow_promotion_codes: true,
     return_url: `${WEBAPP_URL}/api/teams/${teamId}/upgrade?session_id={CHECKOUT_SESSION_ID}`,

--- a/packages/types/stripe.d.ts
+++ b/packages/types/stripe.d.ts
@@ -1,0 +1,11 @@
+import "stripe";
+
+declare module "stripe" {
+  namespace Stripe {
+    namespace Checkout {
+      interface SessionCreateParams {
+        ui_mode?: "embedded" | "hosted";
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR provides a comprehensive fix for all TypeScript build errors that were preventing successful Vercel deployment.

## Root Cause

The build was failing due to:
1. Stripe SDK v18.3.0 includes the `ui_mode` parameter at runtime, but the TypeScript types were not updated
2. The `eventTypeId` parameter handling was causing type mismatches

## Changes

### 1. Added Stripe Type Declarations
- Created `packages/types/stripe.d.ts` to properly extend Stripe types
- Added support for `ui_mode?: 'embedded'  < /dev/null |  'hosted'` parameter
- This is the proper way to handle type extensions rather than using `@ts-expect-error`

### 2. Removed @ts-expect-error Comments
- Removed all `@ts-expect-error` comments from:
  - `PaymentService.ts`
  - `payments.ts` (both occurrences)
- These are no longer needed with proper type declarations

### 3. Fixed eventTypeId Type Handling
- Changed from `(rawBookingData.eventTypeId || 0) as number`
- To `Number(rawBookingData.eventTypeId) || 0`
- This properly converts undefined, null, or string values to numbers

## Testing

✅ All TypeScript errors resolved
✅ `yarn build` completes successfully
✅ No more `ui_mode` type errors
✅ No more `eventTypeId` type mismatches

## Build Status

The build now completes without any TypeScript errors. The warnings about 'use client' and sourcemaps are just warnings and don't prevent deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>